### PR TITLE
Bugfix on_settings_cleanup missing argument self

### DIFF
--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -152,7 +152,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
 
     def on_settings_cleanup(self):
         self.removeButtons()
-        octoprint.plugin.SettingsPlugin.on_settings_cleanup()
+        octoprint.plugin.SettingsPlugin.on_settings_cleanup(self)
 
     def get_settings_defaults(self):
         return dict(


### PR DESCRIPTION
Added the missing self argument to _octoprint.plugin.SettingsPlugin.on_settings_cleanup(self)_.