### PR TITLE
[WIP] Feature execute gcode files

### DIFF
--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -80,7 +80,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                     path = line.replace('@file:','').split(";")[0].strip()
                     try:
                         self._printer.select_file(path, False, printAfterSelect = True)
-                        self._logger.debug("Starting execution of file '%s'" %path )
+                        self._logger.debug("Executing file '%s'" %path )
                         continue
                     except (octoprint.printer.InvalidFileType, octoprint.printer.InvalidFileLocation) as e:
                         self._logger.error(e)
@@ -93,7 +93,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                     path = line.replace('@file_sd:','').split(";")[0].strip()
                     try:
                         self._printer.select_file(path, True, printAfterSelect = True)
-                        self._logger.debug("Starting execution of file '%s'" %path )
+                        self._logger.debug("Executing file '%s'" %path )
                         continue
                     except (octoprint.printer.InvalidFileType, octoprint.printer.InvalidFileLocation) as e:
                         self._logger.error(e)

--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -76,13 +76,15 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
             if '@file:' in line:
             ## Either an absolute path or relative path
             ## to a local file in the uploads folder
-                path = line.replace('@file:','').split(";")[0].strip()
-                self._printer.select_file(path, False, printAfterSelect = True)
+                if self._printer.is_ready():
+                    path = line.replace('@file:','').split(";")[0].strip()
+                    self._printer.select_file(path, False, printAfterSelect = True)
                 continue
             if '@file_sd:' in line:
             ## An absolute path to a local file on the SD card
-                path = line.replace('@file_sd:','').split(";")[0].strip()
-                self._printer.select_file(path, True, printAfterSelect = True)
+                if self._printer.is_ready():
+                    path = line.replace('@file_sd:','').split(";")[0].strip()
+                    self._printer.select_file(path, True, printAfterSelect = True)
                 continue
             ## Normal GCODE command
             cmd = line.split(";")[0].strip()

--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -86,7 +86,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                         self._logger.error(e)
                         break
                 else:
-                    self._logger.error('Could not execute file as printer is not ready')
+                    self._logger.error('Printer is not ready, could not execute file')
             if '@file_sd:' in line:
             ## An absolute path to a local file on the SD card
                 if self._printer.is_ready():
@@ -99,7 +99,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                         self._logger.error(e)
                         break
                 else:
-                    self._logger.error('Could not execute file as printer is not ready')
+                    self._logger.error('Printer is not ready, could not execute file')
             ## Normal GCODE command
             cmd = line.split(";")[0].strip()
             self._printer.commands(cmd, force = False)

--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -72,12 +72,21 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
         t.start()
 
     def sendGcode(self, gcodetxt):
-        #split gcode lines in single commands without comment and add to list
-        commandList = []
-        for temp in gcodetxt.splitlines():
-            commandList.append(temp.split(";")[0].strip())
-        #send commandList to printer
-        self._printer.commands(commandList, force = False)
+        for line in gcodetxt.splitlines():
+            if '@file:' in line:
+            ## Either an absolute path or relative path
+            ## to a local file in the uploads folder
+                path = line.replace('@file:','').split(";")[0].strip()
+                self._printer.select_file(path, False, printAfterSelect = True)
+                continue
+            if '@file_sd:' in line:
+            ## An absolute path to a local file on the SD card
+                path = line.replace('@file_sd:','').split(";")[0].strip()
+                self._printer.select_file(path, True, printAfterSelect = True)
+                continue
+            ## Normal GCODE command
+            cmd = line.split(";")[0].strip()
+            self._printer.commands(cmd, force = False)
 
     def sendAction(self, action):
         if action == "cancel":

--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -80,6 +80,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                     path = line.replace('@file:','').split(";")[0].strip()
                     try:
                         self._printer.select_file(path, False, printAfterSelect = True)
+                        self._logger.debug("Starting execution of file '%s'" %path )
                         continue
                     except (octoprint.printer.InvalidFileType, octoprint.printer.InvalidFileLocation) as e:
                         self._logger.error(e)
@@ -92,6 +93,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                     path = line.replace('@file_sd:','').split(";")[0].strip()
                     try:
                         self._printer.select_file(path, True, printAfterSelect = True)
+                        self._logger.debug("Starting execution of file '%s'" %path )
                         continue
                     except (octoprint.printer.InvalidFileType, octoprint.printer.InvalidFileLocation) as e:
                         self._logger.error(e)

--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -86,7 +86,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                         self._logger.error(e)
                         break
                 else:
-                    self._logger.error('Printer is not ready, could not execute file')
+                    self._logger.error('Printer not ready, could not execute file')
             if '@file_sd:' in line:
             ## An absolute path to a local file on the SD card
                 if self._printer.is_ready():
@@ -99,7 +99,7 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
                         self._logger.error(e)
                         break
                 else:
-                    self._logger.error('Printer is not ready, could not execute file')
+                    self._logger.error('Printer not ready, could not execute file')
             ## Normal GCODE command
             cmd = line.split(";")[0].strip()
             self._printer.commands(cmd, force = False)

--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -78,14 +78,26 @@ class PhysicalbuttonPlugin(octoprint.plugin.StartupPlugin,
             ## to a local file in the uploads folder
                 if self._printer.is_ready():
                     path = line.replace('@file:','').split(";")[0].strip()
-                    self._printer.select_file(path, False, printAfterSelect = True)
-                continue
+                    try:
+                        self._printer.select_file(path, False, printAfterSelect = True)
+                        continue
+                    except (octoprint.printer.InvalidFileType, octoprint.printer.InvalidFileLocation) as e:
+                        self._logger.error(e)
+                        break
+                else:
+                    self._logger.error('Could not execute file as printer is not ready')
             if '@file_sd:' in line:
             ## An absolute path to a local file on the SD card
                 if self._printer.is_ready():
                     path = line.replace('@file_sd:','').split(";")[0].strip()
-                    self._printer.select_file(path, True, printAfterSelect = True)
-                continue
+                    try:
+                        self._printer.select_file(path, True, printAfterSelect = True)
+                        continue
+                    except (octoprint.printer.InvalidFileType, octoprint.printer.InvalidFileLocation) as e:
+                        self._logger.error(e)
+                        break
+                else:
+                    self._logger.error('Could not execute file as printer is not ready')
             ## Normal GCODE command
             cmd = line.split(";")[0].strip()
             self._printer.commands(cmd, force = False)


### PR DESCRIPTION
This pull request adds two prefixes to react to in the GCODE activity, namely '@file:' and '@file_sd:'

With **@file:** you can specify an absolute path to a GCODE-file, or a relative path from the uploads folder on your raspberry pi
With **@file_sd:** you can specify the path to a GCODE-file on the SD of your printer.
