### PR TITLE
Add action to unselect file

### DIFF
--- a/extras/physicalbutton.md
+++ b/extras/physicalbutton.md
@@ -93,7 +93,7 @@ You can edit, move or remove activities in the right pane.
 * **Choose activities for your button**
   * Action:
     * You can choose between different actions:  
-    connect, disconnect, home (x, y and z are homed), pause, resume, start, start latest, cancel, toggle pause-resume, toggle start-cancel, toggle start latest-cancel
+    connect, disconnect, home (x, y and z are homed), pause, resume, start, start latest, cancel, toggle pause-resume, toggle start-cancel, toggle start latest-cancel, unselect file
   * File:
     * You can specify the path to a file which will be selected.
     * To start the execution of a file, add 'start action' behind the 'file activity'.

--- a/octoprint_physicalbutton/__init__.py
+++ b/octoprint_physicalbutton/__init__.py
@@ -171,6 +171,8 @@ class PhysicalbuttonPlugin(octoprint.plugin.AssetPlugin,
             return self.toggle_cancel_print()
         if action == 'toggle start latest-cancel':
             return self.toggle_cancel_start_latest()
+        if action == 'unselect file':
+            return self._printer.unselect_file()
 
         self._logger.debug(f"No action selected or action (yet) unknown")
         return 0

--- a/octoprint_physicalbutton/static/js/physicalbutton.js
+++ b/octoprint_physicalbutton/static/js/physicalbutton.js
@@ -18,7 +18,7 @@ $(function() {
          ]);
          //actions:
          self.actions = ko.observableArray(['none', 'connect', 'disconnect', 'home', 'pause', 'resume', 'toggle pause-resume',
-                                            'start', 'start latest', 'cancel', 'toggle start-cancel', 'toggle start latest-cancel']);
+                                            'start', 'start latest', 'cancel', 'toggle start-cancel', 'toggle start latest-cancel', 'unselect file']);
 
         //button modes:
         self.buttonModes = ko.observableArray(['Normally Open (NO)', 'Normally Closed (NC)']);


### PR DESCRIPTION
I added an action that simply unselects the currently select file (if any).

I'm working on an automated print queue system that works with multiple printers and I need to be able to tell when the next print can be started. The idea is that whenever I clear the print bed after a print is complete, I can hit a button on the printer. This will unselect the file, changing the job progress from 100 to none. This can be used as an indication of the printer being ready for another print. Not sure if anyone else will find any use for this action, but I figured I'd put it out there just in case.

I would have liked to add it as a "file" activity, but I feel like it's a bit cleaner to just add it as an "action"?