### PR TITLE
LED indicator for pressed buttons

### DIFF
--- a/extras/physicalbutton.md
+++ b/extras/physicalbutton.md
@@ -88,6 +88,8 @@ You can edit, move or remove activities in the right pane.
       * Use this mode if your button is usually not pressed (open).
     * Normally Closed (NC)
       * Use this mode if your button is usually pressed (closed).
+* **LED-GPIO**
+    * Each button-state can be visualized by a LED connected to a GPIO-pin.
 * **Hold Time**
   * This is where you set the hold time for your button, meaning how long the button has to be held until the reaction is triggered.
 * **Choose activities for your button**

--- a/octoprint_physicalbutton/static/js/physicalbutton.js
+++ b/octoprint_physicalbutton/static/js/physicalbutton.js
@@ -55,12 +55,16 @@ $(function() {
             }
         }
 
-        self.disableGpioOption = function(item, currentGPIO) {
+        self.disableGpioOption = function(item, currentGPIO, disableLEDs) {
             if (item == 'none' || item == currentGPIO())
                 return false;
 
             //disable used input gpios
             if (self.buttons().find(b => b.gpio() == item))
+                return true;
+
+            //disable used LEDs
+            if (disableLEDs && self.buttons().find(b => b.ledgpio() == item))
                 return true;
 
             //disable used output gpios
@@ -88,6 +92,7 @@ $(function() {
                 buttonMode: ko.observable('Normally Open (NO)'),
                 buttonName: ko.observable('New Button Name'),
                 gpio: ko.observable('none'),
+                ledgpio: ko.observable('none'),
                 buttonTime: ko.observable('500'),
                 id: ko.observable(Date.now())
             });

--- a/octoprint_physicalbutton/templates/physicalbutton_settings.jinja2
+++ b/octoprint_physicalbutton/templates/physicalbutton_settings.jinja2
@@ -52,12 +52,21 @@
                                     <a data-toggle="modal" href="#gpioHelp"><i class="fas fa-question-circle"></i></a>
                                 </div>
                                 <select data-bind="foreach: {data:$root.gpios, as: 'gpioListItem'}, value:button.gpio">
-                                    <option data-bind="value:$data, text: gpioListItem == 'none' ? gpioListItem : 'GPIO' + gpioListItem, disable: $root.disableGpioOption(gpioListItem,button.gpio)"></option>
+                                    <option data-bind="value:$data, text: gpioListItem == 'none' ? gpioListItem : 'GPIO' + gpioListItem, disable: $root.disableGpioOption(gpioListItem,button.gpio,true)"></option>
                                 </select>
                             </div>
                             <div class="control-group choose-mode">
                                 <label for="" title="Choose a mode for your button">Mode:</label>
                                 <select data-bind="value: button.buttonMode, options:$root.buttonModes"></select>
+                            </div>
+                            <div class="control-group choose-gpio-led">
+                                <div class="control-group gpio-help">
+                                    <label for="" title="Choose a  pin for your button-LED (Chosen in BCM-mode)">LED-GPIO: </label>
+                                    <a data-toggle="modal" href="#gpioHelp"><i class="fas fa-question-circle"></i></a>
+                                </div>
+                                <select data-bind="foreach: {data:$root.gpios, as: 'gpioListItem'}, value:button.ledgpio">
+                                    <option data-bind="value:$data, text: gpioListItem == 'none' ? gpioListItem : 'GPIO' + gpioListItem, disable: $root.disableGpioOption(gpioListItem,button.ledgpio,false)"></option>
+                                </select>
                             </div>
                             <div class="control-group choose-time">
                                 <label for="" title="Choose how long the button has to be activated until an activity triggers">Hold Time (ms):</label>


### PR DESCRIPTION
# LED indicator for pressed buttons

This PR proposes to add an optional LED-indicator for one or multiple buttons.
PhysicalButton uses this setting to indicate the press of the button using the specified GPIO-pin.

**Added Features**:
* Added the setting "LED-GPIO"
* Multiple buttons can use the same LED to indicate button presses.
* For security reasons, in case a pin has been used for such an indicator pin, the pin will be disabled for other uses than as an indicator for button presses. This prevents unintentional changes of a pin from "output" to "input". Similarly, GPIO-pins used for buttons cannot be used for this new functionality.

----

**Note**:
I am a bit unsure about the backwards-compatibility of the settings.
Does the code need to reflect previous versions that did not use the new setting?

Best,
*da-h*